### PR TITLE
Added CIS group for prowler reports

### DIFF
--- a/checks/check41
+++ b/checks/check41
@@ -29,7 +29,7 @@ CHECK_CAF_EPIC_check41='Infrastructure Security'
 check41(){
   # "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to port 22 (Scored)"
   for regx in $REGIONS; do
-    SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`22` && ToPort>=`22`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
+    SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`22` && ToPort>=`22`)) && IpProtocol == `tcp` && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
         textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0" "$regx" "$SG"

--- a/groups/group1001_bscislevel1
+++ b/groups/group1001_bscislevel1
@@ -12,4 +12,4 @@ GROUP_ID[1001]='bscislevel1'
 GROUP_NUMBER[1001]='1001.0'
 GROUP_TITLE[1001]='CIS Level 1 - CIS only - [bscislevel1] ***************************'
 GROUP_RUN_BY_DEFAULT[1001]='N' # run it when execute_all is called
-GROUP_CHECKS[1001]='check11,check12,check13,check14,check15,check16,check17,check18,check19,check110,check111,check112,check113,check115,check116,check117,check118,check120,check122,check21,check23,check24,check26,check31,check32,check33,check34,check35,check38,check312,check313,check314,check41,check42'
+GROUP_CHECKS[1001]='check11,check12,check14,check15,check16,check17,check18,check19,check110,check111,check112,check113,check115,check116,check117,check118,check120,check122,check21,check23,check24,check26,check31,check32,check33,check34,check35,check38,check312,check313,check314,check41,check42'


### PR DESCRIPTION
- Check only TCP rule for port 22.
- Removed check 13(Ensure credentials unused for 90 days or greater are disabled ) as -> passwords rotate in 90 days as per password policy, hence this check becomes redundant.